### PR TITLE
fix: correctly set metadata for badmin groups

### DIFF
--- a/addons/igs-core/lua/igs/extensions/badmin.lua
+++ b/addons/igs-core/lua/igs/extensions/badmin.lua
@@ -21,5 +21,5 @@ function STORE_ITEM:SetBAdminGroup(rank)
 			self:Setup(pl)
 
 		end
-	end):SetMeta("bagroup", sUserGroup)
+	end):SetMeta("bagroup", rank)
 end


### PR DESCRIPTION
It seems that `sUserGroup` is undefined here, so metadata.bagroup is always empty

I was a bit confused until I noticed this issue